### PR TITLE
修复编辑器不能初始化值的问题，添加双向同步绑定功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "kindeditor": "^4.1.10",
-    "vue": "^2.2.2"
+    "vue": "^2.3.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,11 @@
 <template>
   <div id="app">
-    <editor id="editor_id" height="500px" width="700px" :content="editorText"
+    <editor id="editor_id" height="500px" width="700px" :content.sync="editorText"
             :afterChange="afterChange()"
             pluginsPath="/static/kindeditor/plugins/"
             :loadStyleMode="false"
             @on-content-change="onContentChange"></editor>
+    <div> editorTextCopy: {{ editorTextCopy }} </div>
   </div>
 </template>
 
@@ -14,14 +15,18 @@ export default {
   name: 'app',
   data () {
     return {
-      editorText: ''
+      editorText: '直接初始化值', // 双向同步的变量
+      editorTextCopy: ''  // content-change 事件回掉改变的对象
     }
+  },
+  mounted () {
+    this.editorText = '<h3>页面载入绑定后，初始化值</h3>'
   },
   created () {
   },
   methods: {
     onContentChange (val) {
-      this.editorText = val
+      this.editorTextCopy = val
     },
     afterChange () {
     }

--- a/src/components/KindEditor.vue
+++ b/src/components/KindEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="kindeditor">
-    <textarea :id="id" name="content" content="outContent"></textarea>
+    <textarea :id="id" name="content">{{ outContent }}</textarea>
   </div>
 </template>
 
@@ -9,6 +9,7 @@ export default {
   name: 'kindeditor',
   data () {
     return {
+      editor: null,
       outContent: this.content
     }
   },
@@ -279,15 +280,16 @@ export default {
   },
   watch: {
     content (val) {
-      this.outContent = val
+      this.editor && val !== this.outContent && this.editor.html(val)
     },
     outContent (val) {
+      this.$emit('update:content', val)
       this.$emit('on-content-change', val)
     }
   },
   mounted () {
     var _this = this
-    window.editor = window.KindEditor.create('#' + this.id, {
+    _this.editor = window.KindEditor.create('#' + this.id, {
       width: _this.width,
       height: _this.height,
       minWidth: _this.minWidth,


### PR DESCRIPTION
0. 修复编辑器不能初始化值的问题
1. 支持页面初始化后绑定变量赋值
2. 支持双向绑定变量（vue2.3.0+）